### PR TITLE
Fix Reinitiate Micro Deposits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsefi-dev-js-api-wrapper",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synapsefi-dev-js-api-wrapper",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/src/apiReqs/apiReqsForNodes.js
+++ b/src/apiReqs/apiReqsForNodes.js
@@ -235,19 +235,13 @@ module.exports[POST_ACH_WITH_AC_RN] = ({ bodyParams, userInfo }) => {
 module.exports[PATCH_REINITIATE_MICRO_DEPOSIT] = ({ node_id, userInfo }) => {
   const { oauth_key, host, user_id, fingerprint, ip_address } = userInfo;
 
-  const res = replacePathParams({
-    originalUrl: `${host}${staticEndpoints[PATCH_REINITIATE_MICRO_DEPOSIT]}`,
-    user_id,
-    node_id,
-  });
-
   return axios.patch(
     replacePathParams({
       originalUrl: `${host}${staticEndpoints[PATCH_REINITIATE_MICRO_DEPOSIT]}`,
       user_id,
       node_id,
     }),
-    {},
+    { resend_micro: 'YES' },
     {
       headers: buildHeaders({
         fingerprint,


### PR DESCRIPTION
Description:
Reinitiate micro deposits call not working on uat-dashboard host with empty req body `{}`. Works with `resend_micro: 'YES'` in the req body.

Updates:
- Added req body for reinitiate micro deposits.
- Rm a couple unused lines.

Notes:
- Tested the same call (w the req body) on normal API route and call still works as intended.