### PR TITLE
handle undefined bodyParams for Oauth req

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 temp.js
 dist
 keys_dev.js
+.DS_Store
 synapse-base-control.json

--- a/src/apiReqs/apiReqsForOAuth.js
+++ b/src/apiReqs/apiReqsForOAuth.js
@@ -9,8 +9,9 @@ module.exports[POST_OAUTH_USER] = ({ bodyParams, userInfo }) => {
   const { user_id, host, refresh_token, headers } = userInfo;
 
   const reqBody = bodyParams !== undefined ? bodyParams : { refresh_token };
+  const email = bodyParams !== undefined ? bodyParams.email : '';
+  const password = bodyParams !== undefined ? bodyParams.password : '';
 
-  const { email, password } = bodyParams;
   const isLoginURL = email && password;
 
   return axios.post(

--- a/src/apiReqs/apiReqsForOAuth.js
+++ b/src/apiReqs/apiReqsForOAuth.js
@@ -9,8 +9,7 @@ module.exports[POST_OAUTH_USER] = ({ bodyParams, userInfo }) => {
   const { user_id, host, refresh_token, headers } = userInfo;
 
   const reqBody = bodyParams !== undefined ? bodyParams : { refresh_token };
-  const email = bodyParams !== undefined ? bodyParams.email : '';
-  const password = bodyParams !== undefined ? bodyParams.password : '';
+  const { email = '', password = '' } = bodyParams || {};
 
   const isLoginURL = email && password;
 


### PR DESCRIPTION
**Task Link**: [Monday.com])https://synapsepay.monday.com/boards/180157847/pulses/382304610

**Description**: 
Clicking on extend session link on session banner does not extend session

**Updates**:
Updated js api wrapper for dev dash to account for undefined bodyParams when an Oauth request is made.

**Visuals**:
![Screen Shot 2019-12-18 at 1 50 49 PM](https://user-images.githubusercontent.com/52716579/71126697-5bfbcf00-219e-11ea-828b-389ccede0a38.png)
![Screen Shot 2019-12-18 at 1 46 52 PM](https://user-images.githubusercontent.com/52716579/71126748-77ff7080-219e-11ea-8ad0-69403393d4f1.png)


