### PR TITLE
ENGC-6525 add or condition in buildheader for blank fingerprint

### DIFF
--- a/src/helpers/buildHeaders.js
+++ b/src/helpers/buildHeaders.js
@@ -6,7 +6,7 @@ const getHeader_X_SP_GAGEWAY = ({ client_id, client_secret }) => {
 };
 
 const getHeader_X_SP_USER = ({ oauth_key, fingerprint }) => {
-  if (oauth_key && fingerprint) return `${oauth_key}|${fingerprint}`;
+  if ((oauth_key && fingerprint) || (oauth_key && fingerprint === '')) return `${oauth_key}|${fingerprint}`;
   if (oauth_key && !fingerprint) return oauth_key;
   if (!oauth_key && fingerprint) return `|${fingerprint}`;
   return 'xxxx|xxxx';

--- a/src/helpers/buildHeaders.js
+++ b/src/helpers/buildHeaders.js
@@ -1,4 +1,4 @@
-const validFP = value => value === '' || value.length > 0;
+const validFP = value => typeof value === 'string' ? (value === '' || value.length > 0) : false;
 
 const getHeader_X_SP_GAGEWAY = ({ client_id, client_secret }) => {
   if (client_id && client_secret) return `${client_id}|${client_secret}`;

--- a/src/helpers/buildHeaders.js
+++ b/src/helpers/buildHeaders.js
@@ -1,3 +1,5 @@
+const validFP = value => value === '' || value.length > 0;
+
 const getHeader_X_SP_GAGEWAY = ({ client_id, client_secret }) => {
   if (client_id && client_secret) return `${client_id}|${client_secret}`;
   if (client_id && !client_secret) return client_id;
@@ -6,9 +8,10 @@ const getHeader_X_SP_GAGEWAY = ({ client_id, client_secret }) => {
 };
 
 const getHeader_X_SP_USER = ({ oauth_key, fingerprint }) => {
-  if ((oauth_key && fingerprint) || (oauth_key && fingerprint === '')) return `${oauth_key}|${fingerprint}`;
-  if (oauth_key && !fingerprint) return oauth_key;
-  if (!oauth_key && fingerprint) return `|${fingerprint}`;
+  if (oauth_key && validFP(fingerprint)) return `${oauth_key}|${fingerprint}`;
+  if (oauth_key && !validFP(fingerprint)) return oauth_key;
+  if (!oauth_key && validFP(fingerprint)) return `|${fingerprint}`;
+
   return 'xxxx|xxxx';
 };
 
@@ -22,7 +25,7 @@ module.exports = ({ client_id, client_secret, oauth_key, fingerprint, ip_address
     headers['X-SP-GATEWAY'] = getHeader_X_SP_GAGEWAY({ client_id, client_secret });
   }
 
-  if (oauth_key || fingerprint) {
+  if (oauth_key || validFP(fingerprint)) {
     headers['X-SP-USER'] = getHeader_X_SP_USER({ oauth_key, fingerprint });
   }
 

--- a/test/helpersTest/buildHeaders.test.js
+++ b/test/helpersTest/buildHeaders.test.js
@@ -56,4 +56,23 @@ describe('buildHeaders', () => {
 
     expect(outputHeaders).to.deep.equal(targetHeaders);
   });
+  
+  it('build header with blank fingerprint', () => {
+    const outputHeaders = buildHeaders({
+      client_id: 'CLIENT_ID',
+      client_secret: 'CLIENT_SECRET',
+      oauth_key: 'OAUTH_KEY',
+      fingerprint: '',
+      ip_address: 'IP_ADDRESS',
+    });
+
+    const targetHeaders = {
+      'Content-Type': 'application/json',
+      'X-SP-USER-IP': 'IP_ADDRESS',
+      'X-SP-GATEWAY': 'CLIENT_ID|CLIENT_SECRET',
+      'X-SP-USER': 'OAUTH_KEY|',
+    };
+
+    expect(outputHeaders).to.deep.equal(targetHeaders);
+  });
 });


### PR DESCRIPTION
Ticket Link: [JIRA](https://synapsefi.atlassian.net/browse/ENGC-6525)

***Description***
Goalsetter has registered a blank fingerprint, and would like to use v2 app with it.
Right now v2 api wrapper does not build headers correctly if app supplies it with a blank fingerprint. 

***Update***
- Add conditional for blank fingerprint in buildHeaders helper
- Wrote test case

***Test Notes***
- Install mocha globally, or ``` npm run test```
- If you installed mocha globally you can ```mocha [path/buildHeaders.test.js]```
- X-SP-USER should return "OAUTH| or |FINGERPRINT" when fingerprint is blank
***Images***
<img width="676" alt="Screen Shot 2021-07-21 at 4 31 20 PM" src="https://user-images.githubusercontent.com/52716579/126573306-9da435e2-d60c-4749-b485-4d83ac3670ae.png">
